### PR TITLE
Updated Docker Support

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,13 +18,16 @@ ARG OVERLAY_ARCH="amd64"
 # environment settings
 ARG DEBIAN_FRONTEND="noninteractive"
 ENV HOME="/root" \
-	LANGUAGE="en_US.UTF-8" \
-	LANG="en_US.UTF-8" \
-	TERM="xterm"
+LANGUAGE="en_US.UTF-8" \
+LANG="en_US.UTF-8" \
+TERM="xterm"
 
 # add s6 overlay
 ADD https://github.com/just-containers/s6-overlay/releases/download/${OVERLAY_VERSION}/s6-overlay-${OVERLAY_ARCH}-installer /tmp/
 RUN chmod +x /tmp/s6-overlay-${OVERLAY_ARCH}-installer && /tmp/s6-overlay-${OVERLAY_ARCH}-installer / && rm /tmp/s6-overlay-${OVERLAY_ARCH}-installer
+
+# copy sources
+COPY sources.list /etc/apt/
 
 # add additional packages
 RUN \
@@ -68,16 +71,14 @@ rm -rf \
 	/var/tmp/*
 
 # add gohfs
-RUN \
-	wget -O ${GOHFS_PATH} \
-		https://github.com/finzzz/gohfs/releases/download/${GOHFS_VERSION}/${GOHFS_ARCH} && \
-	chmod +x ${GOHFS_PATH}
+ADD https://github.com/finzzz/gohfs/releases/download/${GOHFS_VERSION}/${GOHFS_ARCH} ${GOHFS_PATH}
+RUN chmod +x ${GOHFS_PATH}
 
 # copy local files
 COPY root/ /
 
 # ports and volumes
-EXPOSE 80
-VOLUME /config
+EXPOSE 8080
+VOLUME /data
 
 ENTRYPOINT ["/init"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,8 +8,8 @@ LABEL maintainer="github.com/olofvndrhr"
 
 # gohfs version
 ARG GOHFS_VERSION="0.1.3"
-ARG	GOHFS_ARCH="gohfs-linux-amd64"
-ARG	GOHFS_PATH="/app/gohfs"
+ARG GOHFS_ARCH="gohfs-linux-amd64"
+ARG GOHFS_PATH="/app/gohfs"
 
 # s6 overlay version
 ARG OVERLAY_VERSION="v2.2.0.3"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,7 +7,7 @@ LABEL build_version="Version:- ${VERSION} Build-date:- ${BUILD_DATE}"
 LABEL maintainer="github.com/olofvndrhr"
 
 # gohfs version
-ARG GOHFS_VERSION="0.1.2"
+ARG GOHFS_VERSION="0.1.3"
 ARG	GOHFS_ARCH="gohfs-linux-amd64"
 ARG	GOHFS_PATH="/app/gohfs"
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -61,7 +61,6 @@ mkdir -p \
 	/app \
 	/config \
 	/defaults && \
-mv /usr/bin/with-contenv /usr/bin/with-contenvb && \
 echo "**** cleanup ****" && \
 apt-get purge --auto-remove -y && \
 apt-get clean && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,5 @@
-FROM ghcr.io/linuxserver/baseimage-ubuntu:bionic
+FROM ubuntu:bionic
+
 # set version label
 ARG BUILD_DATE
 ARG VERSION
@@ -6,9 +7,13 @@ LABEL build_version="Version:- ${VERSION} Build-date:- ${BUILD_DATE}"
 LABEL maintainer="github.com/olofvndrhr"
 
 # gohfs version
-ENV GOHFS_VERSION="0.1.2" \
-	GOHFS_PATH="/app/gohfs" \
-	GOHFS_ARCH="gohfs-linux-amd64"
+ARG GOHFS_VERSION="0.1.2"
+ARG	GOHFS_ARCH="gohfs-linux-amd64"
+ARG	GOHFS_PATH="/app/gohfs"
+
+# s6 overlay version
+ARG OVERLAY_VERSION="v2.2.0.3"
+ARG OVERLAY_ARCH="amd64"
 
 # environment settings
 ARG DEBIAN_FRONTEND="noninteractive"
@@ -17,11 +22,20 @@ ENV HOME="/root" \
 	LANG="en_US.UTF-8" \
 	TERM="xterm"
 
+# add s6 overlay
+ADD https://github.com/just-containers/s6-overlay/releases/download/${OVERLAY_VERSION}/s6-overlay-${OVERLAY_ARCH}-installer /tmp/
+RUN chmod +x /tmp/s6-overlay-${OVERLAY_ARCH}-installer && /tmp/s6-overlay-${OVERLAY_ARCH}-installer / && rm /tmp/s6-overlay-${OVERLAY_ARCH}-installer
+
+# add additional packages
 RUN \
  echo "**** install build packages ****" && \
  apt-get update && \
  apt-get install -y --no-install-recommends \
 	autoconf \
+	apt-utils \
+	locales \
+	patch \
+	tzdata \
 	file && \
  echo "**** install runtime packages ****" && \
  apt-get update && \
@@ -35,18 +49,29 @@ RUN \
 	bzip2 \
 	zip \
 	unzip && \
- echo "**** cleanup ****" && \
- apt-get purge --auto-remove -y && \
- apt-get clean && \
- rm -rf \
+echo "**** generate locale ****" && \
+locale-gen en_US.UTF-8 && \
+echo "**** create abc user and make default folders ****" && \
+useradd -u 911 -U -d /config -s /bin/false abc && \
+usermod -G users abc && \
+mkdir -p \
+	/app \
+	/config \
+	/defaults && \
+mv /usr/bin/with-contenv /usr/bin/with-contenvb && \
+echo "**** cleanup ****" && \
+apt-get purge --auto-remove -y && \
+apt-get clean && \
+rm -rf \
 	/tmp/* \
 	/var/lib/apt/lists/* \
 	/var/tmp/*
 
-# get gohfs
+# add gohfs
 RUN \
-	wget -O "${GOHFS_PATH}" \
-		https://github.com/finzzz/gohfs/releases/download/"${GOHFS_VERSION}"/"${GOHFS_ARCH}"
+	wget -O ${GOHFS_PATH} \
+		https://github.com/finzzz/gohfs/releases/download/${GOHFS_VERSION}/${GOHFS_ARCH} && \
+	chmod +x ${GOHFS_PATH}
 
 # copy local files
 COPY root/ /
@@ -54,3 +79,5 @@ COPY root/ /
 # ports and volumes
 EXPOSE 80
 VOLUME /config
+
+ENTRYPOINT ["/init"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -3,7 +3,7 @@
 This project can be run in a Docker container, it exposes only port 8080 (default). It is advised 
 to run this configuration through a reverse proxy providing SSL if the service will be exposed over the internet, or use the integrated feature and provide gohfs with a valid certificate.
 
-Password authentification is disabled per default. To enable it set the required environment variables. You only have to set either "`GOHFS_PASSWORD`" or "`GOHFS_PASSWORD_RAW`".
+Password authentification is disabled per default. To enable it set the required environment variables. You only have to set either `GOHFS_PASSWORD` or `GOHFS_PASSWORD_RAW`.
 
 An minimal example run would be
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -3,37 +3,38 @@
 This project can be run in a Docker container, it exposes only port 8080 (default). It is advised 
 to run this configuration through a reverse proxy providing SSL if the service will be exposed over the internet, or use the integrated feature and provide gohfs with a valid certificate.
 
-Password authentification is disabled per default. To enable it set the required environment variables. You only have to set either "GOHFS_PASSWORD" or "GOHFS_PASSWORD_RAW".
+Password authentification is disabled per default. To enable it set the required environment variables. You only have to set either "`GOHFS_PASSWORD`" or "`GOHFS_PASSWORD_RAW`".
 
 An minimal example run would be
 
     # with docker run
     cd <PROJECT_ROOT>
     docker build . -t finzzz/gohfs:latest
-    docker run -p '8080:8080' -v './config:/config' -v './data:/data' -e PGID=1000 -e PUID=1000 -name gohfs finzzz/gohfs:latest
+    docker run -p '8080:8080' -v './data:/data' -e PGID=1000 -e PUID=1000 -name gohfs finzzz/gohfs:latest
     
-    # with docker-compose (be sure to change the docker network)
+    # with docker-compose
     cd <PROJECT_ROOT>
     docker-compose build
     docker-compose up -d
     
-You can then connect to localhost:8080 or server_ip:8080 to access the application.
+You can then connect to `localhost:8080` or `<server_ip>:8080` to access the application.
 The application will then serve the data from the /data directory, if permissions are set correct.
 
 Supportet environment variables
 -----
-| Name | Description |
-|--|--|
-| **Application** |  |
-| PUID | Unix user ID to run the container as |
-| PGID | Unix group ID to run the container as |
-|  |  |
-| GOHFS_HOST | IP address on which the webserver listens *(default: 0.0.0.0)* |
-| GOHFS_PORT | Port on which the webserver listens *(default: 8080)* |
-| GOHFS_USER | Username for authentification *(default: disabled)* |
-| GOHFS_PASSWORD | Sha256 hashed password for authentification *(default: disabled/empty)* | 
+| Name               | Description                                                               |
+| ------------------ | ------------------------------------------------------------------------- |
+| **Application**    |                                                                           |
+| PUID               | Unix user ID to run the container as                                      |
+| PGID               | Unix group ID to run the container as                                     |
+|                    |                                                                           |
+| GOHFS_HOST         | IP address on which the webserver listens *(default: 0.0.0.0)*            |
+| GOHFS_PORT         | Port on which the webserver listens *(default: 8080)*                     |
+| GOHFS_USER         | Username for authentification *(default: disabled)*                       |
+| GOHFS_PASSWORD     | Sha256 hashed password for authentification *(default: disabled/empty)*   |
 | GOHFS_PASSWORD_RAW | Raw (cleartext) password for authentification *(default: disabled/empty)* |
-| GOHFS_ARGS | Additional gohfs command-line arguments *(e.g. -tls)* |
+| GOHFS_MAXUP        | Maximum upload size in Bytes *(default -1)*                               |
+| GOHFS_ARGS         | Additional gohfs command-line arguments *(e.g. `"-dz -du -dl"`)*          |
 
 
 ### Contribution

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -9,19 +9,20 @@ services:
     ports:
       - 8080:8080
     networks:
-      - network1
+      - webserver
     volumes:
       - ./data:/data              # Data folder for gohfs to serve
     environment:
-      - PUID=1000                 # Unix user ID to run the container as
-      - PGID=1000                 # Unix group ID to run the container as
+      - PUID=1000                 # Unix user ID to run the container as (default 911)
+      - PGID=1000                 # Unix group ID to run the container as (default 911)
 #      - GOHFS_HOST=              # IP address on which the webserver listens (default: 0.0.0.0) 
 #      - GOHFS_PORT=              # Port on which the webserver listens (default: 8080) 
 #      - GOHFS_USER=              # Username for authentification (default: disabled)
 #      - GOHFS_PASSWORD=          # Sha256 hashed password for authentification (default: disabled)
 #      - GOHFS_PASSWORD_RAW=      # Raw (cleartext) password for authentification (default: disabled)
-#      - GOHFS_ARGS=              # Additional gohfs command-line arguments (e.g. -tls)
+#      - GOHFS_MAXUP=             # Maximum upload size in Bytes (default -1)
+#      - GOHFS_ARGS=              # Additional gohfs command-line arguments, separated with spaces (e.g. "-dz -du -dl")
       
 networks:
-  network1:
-    external: true
+  webserver:
+    driver: bridge

--- a/docker/root/etc/cont-init.d/10-adduser
+++ b/docker/root/etc/cont-init.d/10-adduser
@@ -6,50 +6,27 @@ PGID=${PGID:-911}
 groupmod -o -g "$PGID" abc
 usermod -o -u "$PUID" abc
 
+chown abc:abc /app
+chown abc:abc /config
+chown abc:abc /defaults
+
 echo '
 -------------------------------------
-          _         ()
-         | |  ___   _    __
-         | | / __| | |  /  \ 
-         | | \__ \ | | | () |
-         |_| |___/ |_|  \__/
+              _      __     
+             | |    / _|    
+   __ _  ___ | |__ | |_ ___ 
+  / _  |/ _ \|  _ \|  _/ __|
+ | (_| | (_) | | | | | \__ \
+  \__  |\___/|_| |_|_| |___/
+   __/ |                    
+  |___/                     
 
-
-Based on the linuxserver.io alpine image
--------------------------------------'
-if [[ -f /donate.txt ]]; then
-    echo '
-To support the app dev(s) visit:'
-    cat /donate.txt
-fi
-echo '
-To support LSIO projects visit:
-https://www.linuxserver.io/donate/
+Docker Image of github.com/finzzz/gohfs'
+echo "
 -------------------------------------
 GID/UID
--------------------------------------'
-echo "
+-------------------------------------
 User uid:    $(id -u abc)
 User gid:    $(id -g abc)
 -------------------------------------
 "
-
-time32="$(date +%Y)"
-
-if [[ "${time32}" == "1970" || "${time32}" == "1969" ]] && [ "$(uname -m)" == "armv7l" ]; then
-  echo '
-@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
-
-Your DockerHost is most likely running an outdated version of libseccomp
-
-To fix this, please visit https://docs.linuxserver.io/faq#libseccomp
-
-Some apps might not behave correctly without this
-
-@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
-'
-fi
-
-chown abc:abc /app
-chown abc:abc /config
-chown abc:abc /defaults

--- a/docker/root/etc/cont-init.d/20-init
+++ b/docker/root/etc/cont-init.d/20-init
@@ -1,13 +1,8 @@
 #!/usr/bin/with-contenv bash
 
-# compromise solution until temp zip files are fixed
-chown abc:abc /
-
 # permissions
 chown abc:abc  \
 	/data \
-	/app/gohfs
-chmod +x \
 	/app/gohfs
 
 # set env variables
@@ -16,7 +11,13 @@ GOHFS_PORT=${GOHFS_PORT:-8080}
 GOHFS_USER=${GOHFS_USER:-}
 GOHFS_PASSWORD=${GOHFS_PASSWORD:-}
 GOHFS_PASSWORD_RAW=${GOHFS_PASSWORD_RAW:-}
+GOHFS_MAXUP=${GOHFS_MAXUP:--1}
 GOHFS_ARGS=${GOHFS_ARGS:-}
+
+# set default args for gohfs
+DEFAULT_ARGS=(	-dir /data
+				-ziptemp /tmp
+)
 
 # start app
 # check if user and password variables are set
@@ -24,14 +25,30 @@ if [[ -n "$GOHFS_USER" ]] && [[ -n "$GOHFS_PASSWORD" ]]
 	then
 		# start app with sha256 password auth
 		exec s6-setuidgid abc \
-		/app/gohfs -dir /data -host ${GOHFS_HOST} -port ${GOHFS_PORT} -user ${GOHFS_USER} -hpass ${GOHFS_PASSWORD} ${GOHFS_ARGS}
+		/app/gohfs ${DEFAULT_ARGS[@]} \
+					-host ${GOHFS_HOST} \
+					-port ${GOHFS_PORT} \
+					-maxup ${GOHFS_MAXUP} \
+					-user ${GOHFS_USER} \
+					-hpass ${GOHFS_PASSWORD} \
+						${GOHFS_ARGS}
 elif [[ -n "$GOHFS_USER" ]] && [[ -n "$GOHFS_PASSWORD_RAW" ]]
 	then
-		# start app with sha256 password auth
+		# start app with raw password auth
 		exec s6-setuidgid abc \
-		/app/gohfs -dir /data -host ${GOHFS_HOST} -port ${GOHFS_PORT} -user ${GOHFS_USER} -hpass ${GOHFS_PASSWORD_RAW} ${GOHFS_ARGS}
+		/app/gohfs ${DEFAULT_ARGS[@]} \
+					-host ${GOHFS_HOST} \
+					-port ${GOHFS_PORT} \
+					-maxup ${GOHFS_MAXUP} \
+					-user ${GOHFS_USER} \
+					-hpass ${GOHFS_PASSWORD_RAW} \
+						${GOHFS_ARGS}
 	else
 		# start app without password auth
 		exec s6-setuidgid abc \
-		/app/gohfs -dir /data -host ${GOHFS_HOST} -port ${GOHFS_PORT} ${GOHFS_ARGS}
+		/app/gohfs ${DEFAULT_ARGS[@]} \
+					-host ${GOHFS_HOST} \
+					-port ${GOHFS_PORT} \
+					-maxup ${GOHFS_MAXUP} \
+						${GOHFS_ARGS}
 fi

--- a/docker/root/usr/bin/with-contenv
+++ b/docker/root/usr/bin/with-contenv
@@ -1,0 +1,7 @@
+#! /bin/bash
+if [[ -f /var/run/s6/container_environment/UMASK ]] && [[ "$(pwdx $$)" =~ "/run/s6/services/" ]]; then
+  umask $(cat /var/run/s6/container_environment/UMASK)
+  exec /usr/bin/with-contenvb "$@"
+else
+  exec /usr/bin/with-contenvb "$@"
+fi

--- a/docker/root/usr/bin/with-contenv
+++ b/docker/root/usr/bin/with-contenv
@@ -1,7 +1,0 @@
-#! /bin/bash
-if [[ -f /var/run/s6/container_environment/UMASK ]] && [[ "$(pwdx $$)" =~ "/run/s6/services/" ]]; then
-  umask $(cat /var/run/s6/container_environment/UMASK)
-  exec /usr/bin/with-contenvb "$@"
-else
-  exec /usr/bin/with-contenvb "$@"
-fi

--- a/docker/sources.list
+++ b/docker/sources.list
@@ -1,0 +1,12 @@
+deb http://archive.ubuntu.com/ubuntu/ bionic main restricted
+deb-src http://archive.ubuntu.com/ubuntu/ bionic main restricted
+deb http://archive.ubuntu.com/ubuntu/ bionic-updates main restricted
+deb-src http://archive.ubuntu.com/ubuntu/ bionic-updates main restricted
+deb http://archive.ubuntu.com/ubuntu/ bionic universe multiverse
+deb-src http://archive.ubuntu.com/ubuntu/ bionic universe multiverse
+deb http://archive.ubuntu.com/ubuntu/ bionic-updates universe multiverse
+deb-src http://archive.ubuntu.com/ubuntu/ bionic-updates universe multiverse
+deb http://archive.ubuntu.com/ubuntu/ bionic-security main restricted
+deb-src http://archive.ubuntu.com/ubuntu/ bionic-security main restricted
+deb http://archive.ubuntu.com/ubuntu/ bionic-security universe multiverse
+deb-src http://archive.ubuntu.com/ubuntu/ bionic-security universe multiverse


### PR DESCRIPTION
I saw your comment and updated the docker support as follows:

- removed linuxserver.io image
- rebased to official ubuntu image
- changed the temp zip file location
- added new options
- changed docker-compose file that it works without modification
- fixed README

The container still has the s6 overlay, so user mapping still works. If you have any other wishes, just comment it.