### PR TITLE
Updated gohfs version in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,7 +7,7 @@ LABEL build_version="Version:- ${VERSION} Build-date:- ${BUILD_DATE}"
 LABEL maintainer="github.com/olofvndrhr"
 
 # gohfs version
-ARG GOHFS_VERSION="0.1.3"
+ARG GOHFS_VERSION="0.1.4"
 ARG GOHFS_ARCH="gohfs-linux-amd64"
 ARG GOHFS_PATH="/app/gohfs"
 


### PR DESCRIPTION
If you release a new version for gohfs, remember to change the version number in the Dockerfile located in `docker/Dockerfile`